### PR TITLE
Implemented a Dockerfile intended for development

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,0 +1,17 @@
+FROM openjdk:8
+
+RUN apt update && apt install -y curl \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY gradle/ gradle/
+COPY src/main/ src/main/
+COPY build.gradle.kts gradle.properties gradlew settings.gradle.kts ./
+
+RUN ./gradlew --no-daemon assemble
+
+ENV PORT 80
+EXPOSE 80
+VOLUME /app
+
+cmd ["bash"]


### PR DESCRIPTION
I've implemented a Dockerfile intended for development purposes.

It supports the following flows:

**Building and running using docker**
1. Develop as usual
2. Run `docker build -f Dockerfile.development .`
3. Run `docker run -it -p8080:80 [hash] ./gradlew run` with the resulting image hash from step 2

**Interactively use docker for running**
1. Develop as usual
2. Run `docker build -f Dockerfile.development .`
3. Run `docker run -it -p8080:80 [hash]` with the resulting image hash from step 2
4. Interact with `gradle` directly with commands such as `./gradlew run`

**Interactively use docker for building and running**
1. Run ` docker build -f Dockerfile.development .`
2. Run `docker run -it -p8080:80 -v "$(pwd -W)":/app [hash]` with the resulting image hash from step 1
3. Develop as usual and interact with `gradle` through the container. Changes are synchronised between the project directory on the host and the container